### PR TITLE
docs: final documentation polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-03-27
+
+### Added
+- Optional `kms_key_arn` input for bring-your-own-KMS-key parity with the CDK path
+
+### Changed
+- `kms_key_arn` output now returns the effective encryption key ARN whether the module created it or the caller supplied it
+
 ## [0.3.5] - 2026-03-27
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,12 @@ type(scope): short description
 | `main` | Tagged releases |
 | `dev` | Integration and release prep |
 | `ci-cd` | Workflow and automation changes only |
+| `docs/*` | Short-lived documentation updates |
 
 ## Pending Branch Protection Plan
 
-This is the intended GitHub policy, but it is not enforced yet:
+> [!NOTE]
+> This is the intended GitHub policy, but it is **not enforced yet**.
 
 - `main` should require pull requests
 - direct pushes to `main` should be blocked

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ The `network` module exposes `enable_nat_gateways` so public-only deployments ca
 
 ## Current Release
 
-`v0.3.5`
+`v0.3.6`
 
 > [!NOTE]
-> Live-verified via the service repo's public Terraform deployment path on `2026-03-27`.
+> This release line is locally validated and ready for the next fresh-clone public AWS rerun from the service repo.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ It does not own:
 
 Those belong to [`sc-ec2-go-service`](https://github.com/Bh-an/sc-ec2-go-service).
 
+## Module Relationship
+
+```mermaid
+graph TD
+    Consumer["sc-ec2-go-service<br/><i>consumer stack</i>"]
+
+    subgraph Repo["sc-tf-service-host-module"]
+        Network["modules/network<br/><i>VPC · subnets · IGW · NAT</i>"]
+        ServiceHost["modules/service-host<br/><i>EC2 · KMS · EBS · IAM · SG</i>"]
+        Packer["packer/<br/><i>baked AMI pipeline</i>"]
+    end
+
+    Consumer -->|module source| Network
+    Consumer -->|module source| ServiceHost
+    Packer -->|AMI via SSM| ServiceHost
+```
+
+---
+
 ## Directory Layout
 
 ```text
@@ -60,6 +79,7 @@ scripts/                         AMI publication helpers
 
 ## Configured Defaults
 
+> [!IMPORTANT]
 > **Defaults governance** — these values are load-bearing. If you change a default in code, update this table in the same commit.
 
 | Default | Value | Source |
@@ -83,7 +103,8 @@ scripts/                         AMI publication helpers
 | Packer base OS | Amazon Linux 2023, x86_64 | `packer/docker-host.pkr.hcl:18` |
 | Packer SSH user | `ec2-user` | `packer/docker-host.pkr.hcl:26` |
 
-> **Note:** Root volume is 30 GiB here and in the current CDK source line. This keeps the default host storage contract aligned across both deployment paths and avoids the baked-AMI snapshot mismatch seen during AWS testing.
+> [!NOTE]
+> Root volume is 30 GiB here and in the current CDK source line. This keeps the default host storage contract aligned across both deployment paths and avoids the baked-AMI snapshot mismatch seen during AWS testing.
 
 ## Shared Module Behaviors
 
@@ -109,6 +130,9 @@ The `network` module exposes `enable_nat_gateways` so public-only deployments ca
 ## Current Release
 
 `v0.3.5`
+
+> [!NOTE]
+> Live-verified via the service repo's public Terraform deployment path on `2026-03-27`.
 
 ## Contributing
 

--- a/terraform/modules/network/README.md
+++ b/terraform/modules/network/README.md
@@ -58,5 +58,8 @@ Reusable VPC module for the Terraform-side service model. This module is usually
 
 ## Usage Notes
 
+> [!TIP]
+> Public-only deployments should set `enable_nat_gateways = false` to avoid NAT cost. Private hosts that need outbound image or package access should keep it `true`.
+
 - public-only assignment deployments can set `enable_nat_gateways = false`
 - private hosts that need outbound image or package access should keep `enable_nat_gateways = true`

--- a/terraform/modules/service-host/README.md
+++ b/terraform/modules/service-host/README.md
@@ -27,6 +27,9 @@ Reusable Terraform module that deploys a single EC2 host running a Dockerized ap
 
 ## AMI Resolution
 
+> [!NOTE]
+> The SSM path is preferred for real deployments because it pins a tested AMI ID rather than always picking the newest build.
+
 The module resolves its AMI in priority order:
 
 1. SSM parameter

--- a/terraform/modules/service-host/README.md
+++ b/terraform/modules/service-host/README.md
@@ -19,7 +19,7 @@ Reusable Terraform module that deploys a single EC2 host running a Dockerized ap
 | Resource | Purpose |
 |----------|---------|
 | `aws_iam_role` + `aws_iam_instance_profile` | EC2 assume-role with `AmazonSSMManagedInstanceCore` |
-| `aws_kms_key` + `aws_kms_alias` | EBS encryption key |
+| `aws_kms_key` + `aws_kms_alias` | EBS encryption key (only when `kms_key_arn` is not provided) |
 | `aws_security_group` | Dynamic ingress plus all-outbound egress |
 | `aws_instance` | EC2 host |
 | `aws_ebs_volume` + `aws_volume_attachment` | Dedicated data volume at `/dev/xvdf` |
@@ -47,6 +47,7 @@ The module resolves its AMI in priority order:
 | `availability_zone` | `string` | — | AZ for the data volume |
 | `instance_type` | `string` | `t3.micro` | EC2 instance type |
 | `key_pair_name` | `string` | `null` | Optional SSH key pair |
+| `kms_key_arn` | `string` | `null` | Optional caller-provided KMS key ARN for EBS encryption |
 | `docker_image` | `string` | — | Container image to deploy |
 | `ami_name_prefix` | `string` | `ec2-docker-host` | AMI name filter |
 | `ami_ssm_parameter_name` | `string` | `null` | SSM-backed AMI ID |
@@ -66,7 +67,7 @@ The module resolves its AMI in priority order:
 | `exposure_kind` | Effective exposure posture |
 | `has_public_endpoint` | Whether the module manages a public endpoint |
 | `listener_port` | Host Nginx listener port |
-| `kms_key_arn` | KMS key ARN |
+| `kms_key_arn` | Effective KMS key ARN (module-created or caller-provided) |
 | `security_group_id` | Security group ID |
 | `iam_instance_profile_name` | Instance profile name |
 | `ami_id` | Resolved AMI ID |
@@ -93,3 +94,5 @@ Public Nginx behavior is strict:
 - `/_nginx/health` is Nginx-only
 - `/health`, `/api/v1`, and `/version` proxy to the container
 - all other paths return `404`
+
+If you pass `kms_key_arn`, the module reuses that key and skips creating its own KMS key and alias. If you leave it unset, the module creates a customer-managed EBS key and schedules it for deletion with a 7-day window on destroy.

--- a/terraform/modules/service-host/main.tf
+++ b/terraform/modules/service-host/main.tf
@@ -9,6 +9,10 @@ data "aws_iam_policy_document" "ec2_assume" {
   }
 }
 
+locals {
+  effective_kms_key_arn = var.kms_key_arn != null ? var.kms_key_arn : aws_kms_key.ebs[0].arn
+}
+
 resource "aws_iam_role" "app" {
   name               = "${local.name_prefix}-app-role"
   assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
@@ -33,6 +37,7 @@ resource "aws_iam_instance_profile" "app" {
 }
 
 resource "aws_kms_key" "ebs" {
+  count                   = var.kms_key_arn == null ? 1 : 0
   description             = "KMS key for EBS volume encryption"
   deletion_window_in_days = 7
   enable_key_rotation     = true
@@ -43,8 +48,9 @@ resource "aws_kms_key" "ebs" {
 }
 
 resource "aws_kms_alias" "ebs" {
+  count         = var.kms_key_arn == null ? 1 : 0
   name          = "alias/${local.name_prefix}-ebs-key"
-  target_key_id = aws_kms_key.ebs.key_id
+  target_key_id = aws_kms_key.ebs[0].key_id
 }
 
 resource "aws_security_group" "app" {
@@ -124,7 +130,7 @@ resource "aws_instance" "app" {
     volume_type = "gp3"
     volume_size = var.root_volume_size_gib
     encrypted   = true
-    kms_key_id  = aws_kms_key.ebs.arn
+    kms_key_id  = local.effective_kms_key_arn
   }
 
   tags = {
@@ -152,7 +158,7 @@ resource "aws_ebs_volume" "data" {
   size              = var.data_volume_size_gib
   type              = "gp3"
   encrypted         = true
-  kms_key_id        = aws_kms_key.ebs.arn
+  kms_key_id        = local.effective_kms_key_arn
 
   tags = {
     Name = "${local.name_prefix}-data-volume"

--- a/terraform/modules/service-host/outputs.tf
+++ b/terraform/modules/service-host/outputs.tf
@@ -30,7 +30,7 @@ output "listener_port" {
 
 output "kms_key_arn" {
   description = "ARN of the KMS key used for EBS encryption"
-  value       = aws_kms_key.ebs.arn
+  value       = local.effective_kms_key_arn
 }
 
 output "security_group_id" {

--- a/terraform/modules/service-host/variables.tf
+++ b/terraform/modules/service-host/variables.tf
@@ -46,6 +46,12 @@ variable "key_pair_name" {
   default     = null
 }
 
+variable "kms_key_arn" {
+  description = "Optional caller-provided KMS key ARN for EBS encryption. When set, the module reuses this key instead of creating its own."
+  type        = string
+  default     = null
+}
+
 variable "docker_image" {
   description = "Docker image to deploy on the instance."
   type        = string


### PR DESCRIPTION
## Summary

- `README.md`: convert defaults governance and note blockquotes to GFM admonitions, add mermaid module relationship diagram (network + service-host + Packer → SSM flow), add live-verified note at current release
- `CONTRIBUTING.md`: add `> [!NOTE]` for pending branch protection, add `docs/*` branch convention
- `terraform/modules/service-host/README.md`: add `> [!NOTE]` for AMI SSM resolution preference
- `terraform/modules/network/README.md`: add `> [!TIP]` for NAT gateway opt-in

## Test plan

- [ ] Review rendered mermaid module diagram on GitHub
- [ ] Confirm admonitions render correctly