### PR TITLE
fix(terraform): make private host bootstrap more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Made `ingress_rules = null` validation-safe so callers can rely on exposure-derived defaults without tripping Terraform variable validation
+- Added retry/backoff around the first-boot `docker pull` in the service-host bootstrap script to make private-host startup more resilient to transient GHCR pull failures
+
 ## [0.3.6] - 2026-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.7] - 2026-03-29
 
 ### Fixed
 - Made `ingress_rules = null` validation-safe so callers can rely on exposure-derived defaults without tripping Terraform variable validation

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ The `network` module exposes `enable_nat_gateways` so public-only deployments ca
 
 ## Current Release
 
-`v0.3.6`
+`v0.3.7`
 
 > [!NOTE]
-> This release line is live-verified through the service repo's fresh-clone public Terraform path completed on `2026-03-27`.
+> This release line includes the Terraform validation fix for `ingress_rules = null` and the first-boot image-pull retry change. The public Terraform deploy workflow was re-verified from the service repo on `2026-03-29`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Those belong to [`sc-ec2-go-service`](https://github.com/Bh-an/sc-ec2-go-service
 - shared Terraform service-host module for `module-public`, `private`, and `caller-managed` exposure modes
 - encrypted EC2 root and data volumes with either a module-managed KMS key or caller-provided `kms_key_arn`
 - SSM-managed host access and AMI resolution from SSM or latest matching AMI name
+- first-boot container bootstrap that retries transient GHCR image-pull failures before failing the host setup
 
 ## Module Relationship
 

--- a/terraform/modules/service-host/README.md
+++ b/terraform/modules/service-host/README.md
@@ -55,7 +55,7 @@ The module resolves its AMI in priority order:
 | `data_volume_size_gib` | `number` | `10` | Data EBS size |
 | `exposure_kind` | `string` | `module-public` | `module-public`, `private`, or `caller-managed` |
 | `enable_elastic_ip` | `bool` | `true` | Allocate an EIP for `module-public` |
-| `ingress_rules` | `list(object)` | `null` | Explicit ingress rules using either `cidr` or `source_security_group_id` |
+| `ingress_rules` | `list(object)` | `null` | Explicit ingress rules using either `cidr` or `source_security_group_id`; `null` keeps the exposure-mode defaults |
 
 ## Outputs
 
@@ -85,7 +85,7 @@ The first-boot user data script:
 1. prepares the data volume
 2. writes Nginx config
 3. creates the Docker bridge network
-4. pulls and runs the container
+4. pulls the container with retry/backoff and then runs it
 5. waits for app health
 6. validates and restarts Nginx
 

--- a/terraform/modules/service-host/files/user_data.sh.tpl
+++ b/terraform/modules/service-host/files/user_data.sh.tpl
@@ -4,6 +4,29 @@ exec > >(tee /var/log/user-data.log) 2>&1
 
 echo "Starting application deployment..."
 
+retry() {
+  local attempts="$1"
+  local initial_delay="$2"
+  shift 2
+
+  local attempt=1
+  local delay="$initial_delay"
+
+  until "$@"; do
+    local exit_code="$?"
+    if [ "$attempt" -ge "$attempts" ]; then
+      echo "Command failed after $attempt attempts: $*"
+      return "$exit_code"
+    fi
+
+    echo "Command failed (attempt $attempt/$attempts): $*"
+    echo "Retrying in $${delay}s..."
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
 install_if_missing() {
   local binary="$1"
   shift
@@ -66,7 +89,7 @@ sudo docker network inspect ec2-net >/dev/null 2>&1 || \
     ec2-net
 
 sudo docker rm -f ec2-go-service >/dev/null 2>&1 || true
-sudo docker pull ${docker_image}
+retry 5 5 sudo docker pull ${docker_image}
 sudo docker run -d \
   --name ec2-go-service \
   --restart unless-stopped \

--- a/terraform/modules/service-host/variables.tf
+++ b/terraform/modules/service-host/variables.tf
@@ -101,16 +101,16 @@ variable "enable_elastic_ip" {
 variable "ingress_rules" {
   description = "Security group ingress rules for the application instance."
   type = list(object({
-    port        = number
-    description = string
-    cidr        = optional(string)
+    port                     = number
+    description              = string
+    cidr                     = optional(string)
     source_security_group_id = optional(string)
   }))
   default = null
 
   validation {
-    condition = var.ingress_rules == null || alltrue([
-      for rule in var.ingress_rules :
+    condition = alltrue([
+      for rule in coalesce(var.ingress_rules, []) :
       ((rule.cidr != null ? 1 : 0) + (rule.source_security_group_id != null ? 1 : 0)) == 1
     ])
     error_message = "Each ingress rule must set exactly one of cidr or source_security_group_id."

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -91,9 +91,9 @@ variable "exposure_kind" {
 variable "ingress_rules" {
   description = "Security group ingress rules for the application instance."
   type = list(object({
-    port        = number
-    description = string
-    cidr        = optional(string)
+    port                     = number
+    description              = string
+    cidr                     = optional(string)
     source_security_group_id = optional(string)
   }))
   default = null


### PR DESCRIPTION
## Summary
- make  validation-safe so the service workflow can use module defaults
- add retry/backoff around the first-boot Docker image pull in user data
- document the bootstrap resilience and null-default behavior in repo docs

## Validation
- 
- 
- [32m[1mSuccess![0m The configuration is valid.
[0m

Closes #6